### PR TITLE
fix value()

### DIFF
--- a/source/concurrency/package.d
+++ b/source/concurrency/package.d
@@ -153,6 +153,11 @@ struct Result(T) {
   }
   static if (!is(T == void))
     T value() {
+      static immutable cancelledExc = new Exception("Cancelled: ", T.stringof);
+      if (isCancelled)
+          throw cancelledExc;
+      if (isError)
+          throw error;
       return result.get!(Value!T).value;
     }
   Exception error() {


### PR DESCRIPTION
This implementation is much more useful then algebraic exception