### PR TITLE
Convert Exceptions to Throwables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Sender is a lazy Task (in the general sense of the word). It needs to be conne
 
 It can be used to model many asynchronous operations: Futures, Fiber, Coroutines, Threads, etc. It enforces structured concurrency because a Sender cannot start without it being awaited on.
 
- `setValue` is the only one allowed to throw exceptions, and if it does, `setError` is called with the Exception. `setDone` is called when the operation has been cancelled.
+ `setValue` is the only one allowed to throw exceptions, and if it does, `setError` is called with the Throwable. `setDone` is called when the operation has been cancelled.
 
 See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0443r14.html for the C++ proposal for introducing Senders/Receivers.
 

--- a/source/concurrency/error.d
+++ b/source/concurrency/error.d
@@ -1,0 +1,55 @@
+module concurrency.error;
+
+// In order to handle Errors that get thrown on non-main threads we have to make a clone. There are cases where the Error is constructed in TLS, which either might be overwritten with another Error (if the thread continues work and hits another Error), or might point to invalid memory once the thread is cleaned up. In order to be safe we have to clone the Error.
+
+class ThrowableClone(T : Throwable) : T {
+  this(Args...)(Throwable.TraceInfo info, Args args) @safe nothrow {
+    super(args);
+    if (info)
+      this.info = new ClonedTraceInfo(info);
+  }
+}
+
+// The reason it accepts a Throwable is because there might be classes that derive directly from Throwable but aren't Exceptions. We treat them as errors here.
+Throwable clone(Throwable t) nothrow @safe {
+  import core.exception;
+  if (auto a = cast(AssertError)t)
+    return new ThrowableClone!AssertError(t.info, a.msg, a.file, a.line, a.next);
+  if (auto r = cast(RangeError)t)
+    return new ThrowableClone!RangeError(t.info, r.file, r.line, r.next);
+  if (auto e = cast(Error)t)
+    return new ThrowableClone!Error(t.info, t.msg, t.file, t.line, t.next);
+  return new ThrowableClone!Throwable(t.info, t.msg, t.file, t.line, t.next);
+}
+
+class ClonedTraceInfo : Throwable.TraceInfo {
+  string[] buf;
+  this(Throwable.TraceInfo t) @trusted nothrow {
+    if (t) {
+      try {
+        foreach (i, line; t)
+          buf ~= line.idup();
+      } catch (Throwable t) {
+        // alas...
+      }
+    }
+  }
+  override int opApply(scope int delegate(ref const(char[])) dg) const {
+    return opApply((ref size_t, ref const(char[]) buf) => dg(buf));
+  }
+
+  override int opApply(scope int delegate(ref size_t, ref const(char[])) dg) const {
+    foreach(i, line; buf) {
+      if (dg(i,line))
+        return 1;
+    }
+    return 0;
+  }
+
+  override string toString() const {
+    string buf;
+    foreach ( i, line; this )
+      buf ~= i ? "\n" ~ line : line;
+    return buf;
+  }
+}

--- a/source/concurrency/operations/completewithcancellation.d
+++ b/source/concurrency/operations/completewithcancellation.d
@@ -18,7 +18,7 @@ private struct CompleteWithCancellationReceiver(Receiver) {
   void setDone() nothrow @safe {
     receiver.setDone();
   }
-  void setError(Exception e) nothrow @safe {
+  void setError(Throwable e) nothrow @safe {
     receiver.setError(e);
   }
   mixin ForwardExtensionPoints!receiver;

--- a/source/concurrency/operations/finally_.d
+++ b/source/concurrency/operations/finally_.d
@@ -31,7 +31,7 @@ private struct FinallyReceiver(Value, Result, Receiver) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     receiver.setValue(getResult());
   }
   mixin ForwardExtensionPoints!receiver;

--- a/source/concurrency/operations/forwardon.d
+++ b/source/concurrency/operations/forwardon.d
@@ -28,7 +28,7 @@ private struct ForwardOnReceiver(Receiver, Value, Scheduler) {
   void setDone() @safe nothrow {
     DoneSender().via(scheduler.schedule()).connectHeap(receiver).start();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     ErrorSender(e).via(scheduler.schedule()).connectHeap(receiver).start();
   }
   mixin ForwardExtensionPoints!receiver;

--- a/source/concurrency/operations/ignoreerror.d
+++ b/source/concurrency/operations/ignoreerror.d
@@ -36,7 +36,7 @@ private struct IEReceiver(Value, Receiver) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     receiver.setDone();
   }
   mixin ForwardExtensionPoints!receiver;

--- a/source/concurrency/operations/race.d
+++ b/source/concurrency/operations/race.d
@@ -88,7 +88,7 @@ private class State(Value) : StopSource {
   shared SharedBitField!Flags bitfield;
   static if (!is(Value == void))
     Value value;
-  Exception exception;
+  Throwable exception;
   bool noDropouts;
   this(bool noDropouts) {
     this.noDropouts = noDropouts;
@@ -162,7 +162,7 @@ private struct RaceReceiver(Receiver, InnerValue, Value) {
         process(newState);
     }
   }
-  void setError(Exception exception) @safe nothrow {
+  void setError(Throwable exception) @safe nothrow {
     with (state.bitfield.lock(Flags.doneOrError_produced, Counter.tick)) {
       bool last = isLast(newState);
       if (!isDoneOrErrorProduced(oldState)) {

--- a/source/concurrency/operations/retry.d
+++ b/source/concurrency/operations/retry.d
@@ -10,7 +10,7 @@ import std.traits;
 struct Times {
   int max = 5;
   int n = 0;
-  bool failure(Exception e) @safe nothrow {
+  bool failure(Throwable e) @safe nothrow {
     n++;
     return n >= max;
   }
@@ -39,7 +39,7 @@ private struct RetryReceiver(Receiver, Sender, Logic) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     if (logic.failure(e))
       receiver.setError(e);
     else {

--- a/source/concurrency/operations/stopon.d
+++ b/source/concurrency/operations/stopon.d
@@ -28,7 +28,7 @@ private struct StopOnReceiver(Receiver, Value) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     receiver.setError(e);
   }
   auto getStopToken() nothrow @trusted {

--- a/source/concurrency/operations/then.d
+++ b/source/concurrency/operations/then.d
@@ -46,7 +46,7 @@ private struct ThenReceiver(Receiver, Value, Fun) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     receiver.setError(e);
   }
   mixin ForwardExtensionPoints!receiver;

--- a/source/concurrency/operations/toshared.d
+++ b/source/concurrency/operations/toshared.d
@@ -38,7 +38,7 @@ class SharedSender(Sender, Scheduler, ResetLogic resetLogic) if (models!(Sender,
   alias Value = Sender.Value;
   static if (!is(Value == void))
     alias ValueRep = Value;
-  alias InternalValue = Algebraic!(Exception, ValueRep, Done);
+  alias InternalValue = Algebraic!(Throwable, ValueRep, Done);
   alias DG = void delegate(InternalValue) nothrow @safe shared;
   static struct SharedSenderOp(Receiver) {
     SharedSender parent;
@@ -74,7 +74,7 @@ class SharedSender(Sender, Scheduler, ResetLogic resetLogic) if (models!(Sender,
               cb.dispose();
               receiver.setError(e);
             }
-          }, (Exception e){
+          }, (Throwable e){
             receiver.setError(e);
           }, (Done d){
             receiver.setDone();
@@ -114,7 +114,7 @@ class SharedSender(Sender, Scheduler, ResetLogic resetLogic) if (models!(Sender,
       state.value = InternalValue(Done());
       process();
     }
-    void setError(Exception e) @safe nothrow {
+    void setError(Throwable e) @safe nothrow {
       state.value = InternalValue(e);
       process();
     }
@@ -160,6 +160,7 @@ class SharedSender(Sender, Scheduler, ResetLogic resetLogic) if (models!(Sender,
           } else {
             auto localState = state;
             release(); // release early
+            // TODO: what happens if the sender completed after release, but before pushBack?
             localState.dgs.pushBack(dg);
           }
         }

--- a/source/concurrency/operations/toshared.d
+++ b/source/concurrency/operations/toshared.d
@@ -159,8 +159,6 @@ class SharedSender(Sender, Scheduler, ResetLogic resetLogic) if (models!(Sender,
             localState.op.start();
           } else {
             auto localState = state;
-            release(); // release early
-            // TODO: what happens if the sender completed after release, but before pushBack?
             localState.dgs.pushBack(dg);
           }
         }

--- a/source/concurrency/operations/via.d
+++ b/source/concurrency/operations/via.d
@@ -28,7 +28,7 @@ private struct ViaAReceiver(ValueB, ValueA, Receiver) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     receiver.setError(e);
   }
   mixin ForwardExtensionPoints!receiver;
@@ -55,7 +55,7 @@ private struct ViaBReceiver(SenderA, ValueB, Receiver) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     receiver.setError(e);
   }
   mixin ForwardExtensionPoints!receiver;

--- a/source/concurrency/operations/whenall.d
+++ b/source/concurrency/operations/whenall.d
@@ -126,7 +126,7 @@ private class WhenAllState(Value) : StopSource {
   StopCallback cb;
   static if (is(typeof(Value.values)))
     Value value;
-  Exception exception;
+  Throwable exception;
   shared SharedBitField!Flags bitfield;
 }
 
@@ -175,7 +175,7 @@ private struct WhenAllReceiver(Receiver, InnerValue, Value) {
         process(newState);
     }
   }
-  void setError(Exception exception) @safe nothrow {
+  void setError(Throwable exception) @safe nothrow {
     with (state.bitfield.lock(Flags.doneOrError_produced, Counter.tick)) {
       bool last = isLast(newState);
       if (!isDoneOrErrorProduced(oldState)) {

--- a/source/concurrency/operations/withscheduler.d
+++ b/source/concurrency/operations/withscheduler.d
@@ -26,7 +26,7 @@ private struct WithSchedulerReceiver(Receiver, Value, Scheduler) {
   void setDone() @safe nothrow {
     receiver.setDone();
   }
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     receiver.setError(e);
   }
   auto getScheduler() @safe nothrow {

--- a/source/concurrency/operations/withstopsource.d
+++ b/source/concurrency/operations/withstopsource.d
@@ -39,7 +39,7 @@ private struct SSReceiver(Receiver, Value) {
     receiver.setDone();
   }
   // TODO: would be good if we only emit this function in the Sender actually could call it
-  void setError(Exception e) @safe nothrow {
+  void setError(Throwable e) @safe nothrow {
     resetStopCallback();
     receiver.setError(e);
   }

--- a/source/concurrency/operations/withstoptoken.d
+++ b/source/concurrency/operations/withstoptoken.d
@@ -50,7 +50,7 @@ private struct STReceiver(Receiver, Value, Fun) {
   void setDone() nothrow @safe {
     receiver.setDone();
   }
-  void setError(Exception e) nothrow @safe {
+  void setError(Throwable e) nothrow @safe {
     receiver.setError(e);
   }
   mixin ForwardExtensionPoints!receiver;

--- a/source/concurrency/receiver.d
+++ b/source/concurrency/receiver.d
@@ -41,14 +41,14 @@ interface ReceiverObjectBase(T) {
   else
     void setValue(T value = T.init) @safe;
   void setDone() nothrow @safe;
-  void setError(Exception e) nothrow @safe;
+  void setError(Throwable e) nothrow @safe;
   StopToken getStopToken() nothrow @safe;
   SchedulerObjectBase getScheduler() nothrow @safe;
 }
 
 struct NullReceiver(T) {
   void setDone() nothrow @safe @nogc {}
-  void setError(Exception e) nothrow @safe @nogc {}
+  void setError(Throwable e) nothrow @safe @nogc {}
   static if (is(T == void))
     void setValue() nothrow @safe @nogc {}
   else
@@ -57,7 +57,7 @@ struct NullReceiver(T) {
 
 struct ThrowingNullReceiver(T) {
   void setDone() nothrow @safe @nogc {}
-  void setError(Exception e) nothrow @safe @nogc {}
+  void setError(Throwable e) nothrow @safe @nogc {}
   static if (is(T == void))
     void setValue() @safe { throw new Exception("ThrowingNullReceiver"); }
   else

--- a/source/concurrency/stream/package.d
+++ b/source/concurrency/stream/package.d
@@ -170,8 +170,8 @@ auto intervalStream(Duration duration, bool emitAtStart = false) {
     void setDone() @safe nothrow {
       op.receiver.setDone();
     }
-    void setError(Exception e) @safe nothrow {
-      op.receiver.setError(e);
+    void setError(Throwable t) @safe nothrow {
+      op.receiver.setError(t);
     }
     auto getStopToken() @safe {
       return op.receiver.getStopToken();

--- a/source/concurrency/stream/take.d
+++ b/source/concurrency/stream/take.d
@@ -31,8 +31,8 @@ struct TakeReceiver(Receiver, Value) {
     } else
       receiver.setDone();
   }
-  void setError(Exception e) nothrow @safe {
-    receiver.setError(e);
+  void setError(Throwable t) nothrow @safe {
+    receiver.setError(t);
   }
   mixin ForwardExtensionPoints!receiver;
 }

--- a/source/concurrency/stream/tolist.d
+++ b/source/concurrency/stream/tolist.d
@@ -55,8 +55,8 @@ struct ToListReceiver(State) {
   void setDone() @safe nothrow {
     state.receiver.setDone();
   }
-  void setError(Exception e) nothrow @safe {
-    state.receiver.setError(e);
+  void setError(Throwable t) nothrow @safe {
+    state.receiver.setError(t);
   }
   auto getStopToken() nothrow @safe {
     return state.receiver.getStopToken();

--- a/tests/ut/concurrency/sender.d
+++ b/tests/ut/concurrency/sender.d
@@ -59,7 +59,7 @@ import core.atomic : atomicOp;
 
 @("syncWait.thread.then.exception")
 @safe unittest {
-  bool delegate() @safe shared dg = () shared { throw new Exception("Exceptions are rethrown"); };
+  bool delegate() @safe shared dg = () shared { throw new Exception("Exceptions are forwarded"); };
   ThreadSender()
     .then(dg)
     .syncWait()


### PR DESCRIPTION
Throwables are required because we cannot let anything get past us. In single
threaded applications you only have to deal with Exceptions. Any error will
simply propagate upwards and terminate the application. In multi-threaded
applications you cannot have threads die willy-nilly, instead you want the owner
(ultimately the main thread) to know it errored.
and rethrow.

If we only do it for Exceptions, any triggered assert will kill the thread while
the rest of the application hangs waiting until the thread is done.

That is why we catch throwables, move them to the owner, and rethrow there.