### PR TITLE
Add CI jobs that run tests using LDC AddressSanitizer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,12 @@ jobs:
           ulimit -a
           dub -c=unittest-release
 
+      - name: Run asan tests linux
+        if: runner.os == 'Linux' && startsWith(matrix.dc, 'ldc')
+        run: |
+          sudo apt install -y llvm   # provides executable `llvm-symbolizer`
+          LSAN_OPTIONS=suppressions=lsan.supp dub -c=unittest-asan
+
       - name: Run tests windows
         if: runner.os != 'Linux'
         run: |

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,0 +1,4 @@
+# https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions
+
+leak:_D4core6memory__T10pureMallocZQnFNaNbNiNemZPv
+leak:_D4core6memory__T10pureCallocZQnFNaNbNiNemmZPv

--- a/source/concurrency/stoptoken.d
+++ b/source/concurrency/stoptoken.d
@@ -253,7 +253,7 @@ public:
     if (cb.next_ !is null) {
       cb.next_.prev_ = &cb.next_;
     }
-    cb.prev_ = &head_;
+    () @trusted { cb.prev_ = &head_; } ();
     head_ = cb;
 
     if (incrementRefCountIfSuccessful) {


### PR DESCRIPTION
- Uses @trusted to avoid -dip1000 diagnostics error because lack of time. Keeping issue open in a revised shape for now https://github.com/symmetryinvestments/concurrency/issues/29.
- Uses LeakSanitizer (LSan) supression patterns
- Install APT package llvm that provides llvm-symbolizer that convers addresses to symbols in LSan stacktrace.