### PR TITLE
More return scope fixes

### DIFF
--- a/lsan.supp
+++ b/lsan.supp
@@ -4,3 +4,6 @@ leak:_D4core6memory__T10pureMallocZQnFNaNbNiNemZPv
 leak:_D4core6memory__T10pureCallocZQnFNaNbNiNemmZPv
 leak:_D2rt8monitor_13ensureMonitorFNbC6ObjectZPOSQBqQBq7Monitor
 leak:_D2rt5tlsgc4initFNbNiZPv
+# druntime internals:
+# 7 Throwables constructed via core.exception.staticError() leak their malloc'd .info backtrace (these Throwables aren't finalized)
+leak:_D4core7runtime19defaultTraceHandlerFPvZC6object9Throwable9TraceInfo

--- a/source/concurrency/fork.d
+++ b/source/concurrency/fork.d
@@ -102,7 +102,7 @@ struct ForkSender {
     this.fun = fun;
     this.afterFork = afterFork;
   }
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     return new Operation!Receiver(executor, fun, receiver, afterFork);
   }
   static void reinitThreadLocks() {

--- a/source/concurrency/nursery.d
+++ b/source/concurrency/nursery.d
@@ -153,7 +153,7 @@ class Nursery : StopSource {
     return cast(shared)this;
   }
 
-  auto connect(Receiver)(return Receiver receiver) shared scope return @trusted {
+  auto connect(Receiver)(return Receiver receiver) shared @trusted return scope {
     final class ReceiverImpl : ReceiverObject {
       Receiver receiver;
       SchedulerObjectBase scheduler;
@@ -243,7 +243,7 @@ private struct NurseryOp {
   ReceiverObject receiver;
   @disable this(ref return scope typeof(this) rhs);
   @disable this(this);
-  this(return shared Nursery n, StopCallback cb, ReceiverObject r) @safe scope return {
+  this(return shared Nursery n, StopCallback cb, ReceiverObject r) @safe return scope {
     nursery = n;
     this.cb = cb;
     receiver = r;

--- a/source/concurrency/scheduler.d
+++ b/source/concurrency/scheduler.d
@@ -296,7 +296,7 @@ struct ScheduleAfter {
   static assert (models!(typeof(this), isSender));
   alias Value = void;
   Duration duration;
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = receiver.getScheduler.scheduleAfter(duration).connect(receiver);
     return op;
@@ -306,7 +306,7 @@ struct ScheduleAfter {
 struct Schedule {
   static assert (models!(typeof(this), isSender));
   alias Value = void;
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = receiver.getScheduler.schedule().connect(receiver);
     return op;

--- a/source/concurrency/sender.d
+++ b/source/concurrency/sender.d
@@ -277,7 +277,7 @@ struct ThrowingSender {
       receiver.setError(new Exception("ThrowingSender"));
     }
   }
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = Op!Receiver(receiver);
     return op;
@@ -296,7 +296,7 @@ struct DoneSender {
       receiver.setDone();
     }
   }
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = DoneOp!(Receiver)(receiver);
     return op;
@@ -316,7 +316,7 @@ struct VoidSender {
       receiver.setValueOrError();
     }
   }
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = VoidOp!Receiver(receiver);
     return op;
@@ -337,7 +337,7 @@ struct ErrorSender {
       receiver.setError(exception);
     }
   }
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = ErrorOp!(Receiver)(receiver, exception);
     return op;
@@ -367,7 +367,7 @@ template OpType(Sender, Receiver) {
 struct DelaySender {
   alias Value = void;
   Duration dur;
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = receiver.getScheduler().scheduleAfter(dur).connect(receiver);
     return op;
@@ -585,15 +585,18 @@ struct PromiseSender(T) {
   static assert(models!(typeof(this), isSender));
   private shared Promise!T promise;
 
-  auto connect(Receiver)(return Receiver receiver) @trusted scope {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
-    auto op = (cast(shared)this).connect(receiver);
+    auto op = asShared.connect(receiver);
     return op;
   }
   auto connect(Receiver)(return Receiver receiver) @safe shared return scope {
     // ensure NRVO
     auto op = PromiseSenderOp!(T, Receiver)(promise, receiver);
     return op;
+  }
+  private auto asShared() @trusted return scope {
+    return cast(shared)this;
   }
 }
 

--- a/tests/ut/concurrency/operations.d
+++ b/tests/ut/concurrency/operations.d
@@ -211,7 +211,7 @@ struct OutOfBandValueSender(T) {
           receiver.setValue();
       }
     }
-    auto connect(Receiver)(return Receiver receiver) @safe scope return {
+    auto connect(Receiver)(return Receiver receiver) @safe return scope {
       // ensure NRVO
       auto op = Op!(Receiver)(receiver, n++ < t);
       return op;
@@ -242,7 +242,7 @@ struct OutOfBandValueSender(T) {
 struct ConnectCounter {
   alias Value = int;
   int counter = 0;
-  auto connect(Receiver)(return Receiver receiver) @safe {
+  auto connect(Receiver)(return Receiver receiver) @safe return scope {
     // ensure NRVO
     auto op = ValueSender!int(counter++).connect(receiver);
     return op;
@@ -705,7 +705,7 @@ DoneSender().forwardOn(pool.getScheduler).syncWait.isCancelled.should == true;
   static struct Countdown {
     alias Value = void;
     int countdown;
-    auto connect(Receiver)(return Receiver receiver) @safe scope return {
+    auto connect(Receiver)(return Receiver receiver) @safe return scope {
       // ensure NRVO
       auto op = CountdownOp!(Receiver)(receiver, countdown-- == 0);
       return op;

--- a/tests/ut/concurrency/sender.d
+++ b/tests/ut/concurrency/sender.d
@@ -260,7 +260,7 @@ import core.atomic : atomicOp;
   }
   static struct NRVOSender {
     alias Value = bool;
-    auto connect(Receiver)(return Receiver receiver) @safe scope return {
+    auto connect(Receiver)(return Receiver receiver) @safe return scope {
       // ensure NRVO
       auto op = Op!Receiver(receiver);
       return op;


### PR DESCRIPTION
It turns out there is a slight difference between annotating a member function with `scope return` or `return scope`.

The `scope` in both `return scope` and `scope return` means you aren't allowed to escape a pointer member. It is also required if you want to call a method on a variable that has a `scope` annotation.

The `return` in `scope return` means you are allowed to return a reference to a struct's member. Whereas the `return` in `return scope` allows you to return pointer members.

```
struct RS {
    int* p;
    auto get() return scope {
        return p; // returning a pointer member
    }
}

struct SR {
    int p;
    auto get() scope return {
        return &p; // returning a reference to a member, essentially a pointer+offset to the struct
    }
}
```

Many of the connect functions were annotated with `scope return`, but we don't care much about the Sender's lifetime - they are just a collection of values needed to connect the async operation - but rather about the lifetime of Operation returned.