### PR TITLE
Fix PromiseSender for ldc >= 1.35.0

### DIFF
--- a/source/concurrency/sender.d
+++ b/source/concurrency/sender.d
@@ -598,7 +598,7 @@ class Promise(T) {
 			}
 		}
 
-		private auto ref unshared() @trusted nothrow shared {
+		private auto unshared() @trusted nothrow shared {
 			return cast() this;
 		}
 	}


### PR DESCRIPTION
There has been in change in what auto ref means.
Since we have a class this, we can just return the unshared this.