### PR TITLE
Windows: Fix duplicate `concurrency_{globalStopSourcePointer,getLocalThreadExecutor}` symbols

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     name: Dub Tests
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         dc: [dmd-latest, ldc-latest, dmd-2.098.1, ldc-1.28.1]

--- a/README.md
+++ b/README.md
@@ -206,7 +206,12 @@ If you want the termination to happen asynchronously, for instance because the c
 
 The concurrency library is designed to work with dynamic libraries. It exports 2 functions that it uses to load important globals and thread-locals from the host process.
 
-The only requirement is that the linker you are using supports `--export-dynamic-symbol` (at least gold, lld do).
+On Posix, the only requirement is that the linker you are using supports `--export-dynamic-symbol` (at least gold, lld do).
+
+On Windows, you need to export the 2 symbols explicitly from the executable to make the whole process (i.e., DLLs with statically linked `concurrency`) use these. This can be achieved by adding according linker flags for the executable, e.g., in `dub.sdl`:
+```
+lflags "/EXPORT:concurrency_getLocalThreadExecutor" "/EXPORT:concurrency_globalStopSourcePointer" platform="windows"
+```
 
 ## DSemver
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -17,6 +17,7 @@ configuration "unittest" {
 	dflags "-dip1000"
 	sourcePaths "source" "tests"
 	importPaths "source" "tests"
+	lflags "/EXPORT:concurrency_getLocalThreadExecutor" "/EXPORT:concurrency_globalStopSourcePointer" platform="windows"
 }
 configuration "unittest-release" {
 	dependency "unit-threaded" version="*"
@@ -25,6 +26,7 @@ configuration "unittest-release" {
 	dflags "-dip1000" "-g"
 	sourcePaths "source" "tests/ut"
 	importPaths "source" "tests/ut"
+	lflags "/EXPORT:concurrency_getLocalThreadExecutor" "/EXPORT:concurrency_globalStopSourcePointer" platform="windows"
   # buildOptions "unittests"  "optimize"  "inline"
   buildOptions "unittests" "optimize"
 }
@@ -39,6 +41,7 @@ configuration "unittest-asan" {
 	dflags "-dip1000" "-fsanitize=address"
 	sourcePaths "source" "tests/ut"
 	importPaths "source" "tests/ut"
+	lflags "/EXPORT:concurrency_getLocalThreadExecutor" "/EXPORT:concurrency_globalStopSourcePointer" platform="windows"
   # buildOptions "unittests"  "optimize"  "inline"
   buildOptions "unittests"  "optimize"
 }


### PR DESCRIPTION
The `export` visibility causes these 2 special symbols to be exported from every binary the concurrency library is linked statically into. Now if we have a DLL exporting it, and the executable too, and the executable is linked implicitly against the DLL (via .lib import library), the linker complains about duplicate symbols.

So on Windows, it should generally be exported from a single binary in the whole process. AFAICT, the `dynamicLoad` utility checks the executable's exports only, so relies on that exporting binary being the executable. This can be achieved via extra linker flags for the executable; AFAIK, there's unfortunately no way to un-export specific symbols in the linker command-line (which would alternatively allow preventing the export via linker flags for the DLLs).