### PR TITLE
Optimisation: reduce WhenAll operational state

### DIFF
--- a/source/concurrency/receiver.d
+++ b/source/concurrency/receiver.d
@@ -26,7 +26,7 @@ mixin template ForwardExtensionPoints(alias receiver) {
 		return receiver.getScheduler();
 	}
 
-	static if (__traits(hasMember, receiver, "getIOScheduler")) {
+	static if (__traits(compiles, receiver.getIOScheduler())) {
 		auto getIOScheduler() nothrow @safe {
 			return receiver.getIOScheduler();
 		}


### PR DESCRIPTION
Instead of putting the senderCount and the receiver in _each_ result receiver, we put it once in the state. This saves a fair amount of bytes on the `WhenAllReceiver` and saves on stack allocations.

Test Plan: `dub test``