### PR TITLE
Optimisation: reduce size of ScheduleAfterOp

### DIFF
--- a/source/concurrency/io/iouring.d
+++ b/source/concurrency/io/iouring.d
@@ -66,11 +66,14 @@ struct IOUringContext {
         return RunSender!(Sender)(&this, sender);
     }
 
-    private void addTimer(ref Timer timer, Duration dur) @trusted shared {
-        timer.scheduled_at = dur.split!"hnsecs".hnsecs;
-        timer.command = TimerCommand.Register;
+    private void addTimer(ref Timer timer) @trusted shared {
         timers.push(&timer);
         wakeup();
+    }
+
+    private void addTimer(ref Timer timer, Duration dur) @trusted shared {
+        timer.setScheduledAt(dur);
+        addTimer(timer);
     }
 
     private void cancelTimer(ref Timer timer) @trusted shared {
@@ -474,6 +477,10 @@ private struct IOUringTimer {
     import core.time : msecs, Duration;
 
     private shared IOUringContext* context;
+
+    void addTimer(ref Timer timer) @safe {
+        context.addTimer(timer);
+    }
 
     void addTimer(ref Timer timer, Duration dur) @safe {
         context.addTimer(timer, dur);

--- a/source/concurrency/scheduler.d
+++ b/source/concurrency/scheduler.d
@@ -131,7 +131,6 @@ struct ScheduleAfterOp(Worker, Receiver) {
 	}
 
 	Worker worker;
-	Duration dur;
 	Receiver receiver;
 	Timer timer;
 	shared StopCallback stopCb;
@@ -143,6 +142,12 @@ struct ScheduleAfterOp(Worker, Receiver) {
 
     @disable void opAssign(typeof(this) rhs) nothrow @safe @nogc;
     @disable void opAssign(ref typeof(this) rhs) nothrow @safe @nogc;
+
+	this(return Worker worker, Duration dur, return Receiver receiver) @trusted scope {
+		this.worker = worker;
+		this.receiver = receiver;
+		this.timer.setScheduledAt(dur);
+	}
 
 	// ~this() @safe scope {}
 	void start() @trusted scope nothrow {
@@ -156,7 +161,7 @@ struct ScheduleAfterOp(Worker, Receiver) {
 
 		try {
 			timer.userdata = cast(void delegate(TimerTrigger) @safe shared nothrow) &trigger;
-			worker.addTimer(timer, dur);
+			worker.addTimer(timer);
 		} catch (Exception e) {
 			receiver.setError(e);
 			return;
@@ -255,6 +260,11 @@ class ManualTimeWorker {
 
 	ManualTimeScheduler getScheduler() @safe shared {
 		return ManualTimeScheduler(this);
+	}
+
+	void addTimer(ref Timer timer) @trusted shared {
+		import core.time : hnsecs;
+		addTimer(timer, timer.scheduled_at.hnsecs);
 	}
 
 	void addTimer(ref Timer timer, Duration dur) @trusted shared {

--- a/source/concurrency/thread.d
+++ b/source/concurrency/thread.d
@@ -208,6 +208,11 @@ package struct LocalThreadWorker {
 		executor.queue.push(new WorkNode(WorkItem(dg)));
 	}
 
+	void addTimer(ref Timer timer) @trusted {
+		import core.time : hnsecs;
+		addTimer(timer, timer.scheduled_at.hnsecs);
+	}
+
 	void addTimer(ref Timer timer, Duration dur) @trusted {
 		// import core.atomic : atomicOp;
 		// ulong id = executor.nextTimerId.atomicOp!("+=")(1);

--- a/source/concurrency/timingwheels.d
+++ b/source/concurrency/timingwheels.d
@@ -129,6 +129,10 @@ struct ListElement(T) {
 	ushort position = 0xffff;
 	TimerCommand command;
 	ListElement!T* prev, next;
+	void setScheduledAt(Duration dur) @system {
+		scheduled_at = dur.split!"hnsecs".hnsecs;
+		command = TimerCommand.Register;
+	}
 }
 
 enum TimerCommand : ushort {


### PR DESCRIPTION
By moving the duration in the unused timer field, we save on a few bytes for the operational state.

Test Plan: `dub test`